### PR TITLE
Explicitly reset StagedRender.last_render at the end of StagedRender.ini...

### DIFF
--- a/plugin/notmuch.vim
+++ b/plugin/notmuch.vim
@@ -1169,6 +1169,8 @@ ruby << EOF
 			@last_render = 0
 
 			@b.render { do_next }
+
+			@last_render = @b.count
 		end
 
 		def is_ready?


### PR DESCRIPTION
...tialize.

This fixes the issue, that search_refresh kept
@last_render at >=4_win.height, so that
StagedRender.is_ready? always returned false.
That way the search list was limited to only
2_win.height results after a refresh.
