### PR TITLE
Remove notmuch_sendmail option

### DIFF
--- a/doc/notmuch.txt
+++ b/doc/notmuch.txt
@@ -167,6 +167,7 @@ the location of the binary:
 		\ 'location': '/usr/bin/exim',
 		\ }
 <
+The default sendmail method also accepts the 'location' param.
 
 						*g:notmuch_date_format*
 
@@ -190,12 +191,10 @@ If you want to count the threads instead of the messages in the folder view:
 <
 
 						*g:notmuch_reader*
-						*g:notmuch_sendmail*
 
-You can also configure your externail mail reader and sendemail program:
+You can also configure your external mail reader:
 >
 	let g:notmuch_reader = 'mutt -f %s'
-	let g:notmuch_sendmail = 'sendmail'
 <
 
 You can also configure what probram is used to view attachments:

--- a/plugin/notmuch.vim
+++ b/plugin/notmuch.vim
@@ -73,7 +73,6 @@ let s:notmuch_sendmail_param_default = {
 let s:notmuch_date_format_default = '%d.%m.%y'
 let s:notmuch_datetime_format_default = '%d.%m.%y %H:%M:%S'
 let s:notmuch_reader_default = 'mutt -f %s'
-let s:notmuch_sendmail_default = 'sendmail'
 let s:notmuch_view_attachment_default = 'xdg-open'
 let s:notmuch_attachment_tmpdir_default = '~/.notmuch/tmp'
 let s:notmuch_save_sent_locally_default = 1
@@ -416,10 +415,6 @@ function! s:set_defaults()
 
 	if !exists('g:notmuch_reader')
 		let g:notmuch_reader = s:notmuch_reader_default
-	endif
-
-	if !exists('g:notmuch_sendmail')
-		let g:notmuch_sendmail = s:notmuch_sendmail_default
 	endif
 
 	if !exists('g:notmuch_attachment_tmpdir')


### PR DESCRIPTION
The notmuch_sendmail option was not used anywhere in the code, but was still setted and mentionned in the documentation. Removed all useless code about it and updated documentation.