### PR TITLE
Fix error when displaying string with quotes.

### DIFF
--- a/plugin/notmuch.rb
+++ b/plugin/notmuch.rb
@@ -38,7 +38,13 @@ def get_config
 end
 
 def vim_puts(s)
-  VIM::command("echo '#{s.to_s}'")
+  if s.index "'" == nil
+    VIM::command("echo '#{s.to_s}'")
+  elsif s.index '"' == nil
+    VIM::command("echo \"#{s.to_s}\"")
+  else
+    VIM::command("echo \"#{s.gsub(/"/,"").to_s}\"")
+  end
 end
 
 def vim_err(s)


### PR DESCRIPTION
Mostly happen when extracting an attachment with a quote in its name. An error is printed but the attachment is extracted, because the error happen when printing its name.
