### PR TITLE
fix deprecation warning in mail 2.7.0

### DIFF
--- a/plugin/notmuch.rb
+++ b/plugin/notmuch.rb
@@ -232,7 +232,7 @@ def search_render(search)
       authors = e.authors.to_utf8.split(/[,|]/).map { |a| author_filter(a) }.join(",")
       date = Time.at(e.newest_date).strftime(date_fmt)
       subject = e.messages.first['subject']
-      subject = Mail::Field.new("Subject: " + subject).to_s
+      subject = Mail::Field.parse("Subject: " + subject).to_s
       b << "%-12s %3s %-20.20s | %s (%s)" % [date, e.matched_messages, authors, subject, e.tags]
       $curbuf.threads << e.thread_id
     end


### PR DESCRIPTION
ref: https://github.com/mikel/mail/pull/1111

Mail::Field.new is deprecate in mail 2.7.0 so a deprecation warning is
printed everytime it's called. To avoid the warning, use the new api:
Mail::Field.parse